### PR TITLE
add another dum to catch the bcid correctly

### DIFF
--- a/src/tpfit2root.C
+++ b/src/tpfit2root.C
@@ -99,6 +99,7 @@ int main(int argc, char* argv[]) {
       if(getline(ifile ,line)) {
         sline2 << line;
         sline2 >> dum;
+        sline2 >> dum;
         sline2 >> BCID;
         }
       for(int i = 0; i < Nb; i++){


### PR DESCRIPTION
Hey @sezata, I think there was one `sline >> dum` missing here. The decoded format is

`A3ED09CA BCID: 2506`

so it'll need two dum's before catching the BCID.


![image](https://cloud.githubusercontent.com/assets/3323802/25676743/32e6e1da-3011-11e7-9b15-a18fa9084141.png)
