### PR TITLE
Adding a TP BC offset option

### DIFF
--- a/src/combineTPGBT.C
+++ b/src/combineTPGBT.C
@@ -121,6 +121,10 @@ int main( int argc, char *argv[] )  {
     /* tmp5 will only have a value if limit was defined as existing */
     if (tmp5) {
         limit = std::stoi(tmp5);
+        if (limit < 0){
+          std::cout << "ERROR: This value of limit does not make sense: " << limit << std::endl;
+          return 0;
+        }
         std::cout << "The program will cease after this TPFIT entry: " << limit << std::endl;
     }
 

--- a/src/combineTPGBT.C
+++ b/src/combineTPGBT.C
@@ -92,6 +92,8 @@ int main( int argc, char *argv[] )  {
 
     int limit           = -1;
     int offset_BCID     = 0;
+    int BCID_mod        = 0;
+    int BCID_max        = 4096;
 
     /* argument stuff */
     if(argc != 13 && argc != 11 && argc != 9) {
@@ -364,8 +366,18 @@ int main( int argc, char *argv[] )  {
 
             /* if the time difference is acceptable, begin packet comparison */
             if(time_difference < 0.2) {
+
+                /* in case the user wants to adjust the FIT BCID, which is cyclical */
+                if (offset_BCID){
+                    BCID_mod = BCID + offset_BCID;
+                    if      (BCID_mod < 0)        BCID_mod = BCID_mod + BCID_max;
+                    else if (BCID_mod > BCID_max) BCID_mod = BCID_mod - BCID_max;
+                }
+                else
+                    BCID_mod = BCID;
+
                 /* check if the trigger processor output is in the GBT packets */
-                if(std::find(gbtbcids.begin(), gbtbcids.end(), BCID + offset_BCID) != gbtbcids.end()) {
+                if(std::find(gbtbcids.begin(), gbtbcids.end(), BCID_mod) != gbtbcids.end()) {
 
                     for(unsigned int counter2 = 0; counter2 < tpfit_MMFE8->size(); counter2++) {
                         tp_tmp_hit_storage.clear();


### PR DESCRIPTION
@jrfarah Can you take a look at this?

I wanted to add an option for the user to offset the TP BCID by some value, to accommodate a change in the TP firmware. But adding this option (`-b`) would break the code if the user tried using it at the same time as the `limit` option, because the number of args are counted:

``` if(argc==11) { check_for_limit = 1; } ```

I thought an elegant way to work around this was to remove the explicit `check_for_limit` and instead check that the `tmp5` pointer was not null:

``` if (tmp5) { ``` 

This works because you are a good person and initialized the pointer to 0. It is only non-zero when the user defines a limit. And downstream in the event loop, I changed the check of `has_limit` to be `limit != -1`, which is the initialized value of `limit`.

I think the only marginally confusing aspect of this is, what happens if the user provides a limit of -1? But I would claim that if the user asks for `-l -1`, they are drunk and cannot expect well-defined behavior.

Let me know what you think. :cheese:  